### PR TITLE
Remove hardcoded fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Web service that sits between Github and JIRA.
 
 See the `configExample` file for configuration. Note you must have the `context.xml` for the webapp pointed at a config.
 
-**Note:** There's still some hard coded values specific to our JIRA setup I need to change to being injected. In short, don't try to use this yet. 
-
 ## Current features
 ### Issues
 * Created in Github -> JIRA

--- a/src/main/java/net/mostlyharmless/jghservice/JiraGithubService.java
+++ b/src/main/java/net/mostlyharmless/jghservice/JiraGithubService.java
@@ -32,7 +32,7 @@ public class JiraGithubService extends ResourceConfig
     {
         super(net.mostlyharmless.jghservice.resources.jira.JiraWebhook.class,
               net.mostlyharmless.jghservice.resources.github.GithubWebhook.class,
-              //net.mostlyharmless.jghservice.resources.TestResource.class,
+              net.mostlyharmless.jghservice.resources.TestResource.class,
               ObjectMapperProvider.class,
               JacksonFeature.class);
         

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/CreateIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/CreateIssue.java
@@ -66,9 +66,9 @@ public class CreateIssue implements GithubCommand<Integer>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + repo.getGithubOwner() + 
+        return new URL(apiUrlBase + repo.getGithubOwner() + 
                         "/" + repo.getGithubName() + "/issues");
     }
 

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/GetLabelsOnIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/GetLabelsOnIssue.java
@@ -43,9 +43,9 @@ public class GetLabelsOnIssue implements GithubCommand<List<String>>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        String urlString = API_URL_BASE +
+        String urlString = apiUrlBase +
                            repo.getGithubOwner()+
                            "/" +
                            repo.getGithubName()+

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/GithubCommand.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/GithubCommand.java
@@ -31,7 +31,6 @@ import java.net.URL;
  */
 public interface GithubCommand<T>
 {
-    final static String API_URL_BASE = "https://api.github.com/repos/";
     final static String POST = "POST";
     final static String PUT = "PUT";
     final static String GET = "GET";
@@ -41,7 +40,7 @@ public interface GithubCommand<T>
         .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
         .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     
-    URL getUrl() throws MalformedURLException;
+    URL getUrl(String apiUrlBase) throws MalformedURLException;
     String getJson() throws JsonProcessingException;
     String getRequestMethod();
     int getExpectedResponseCode();

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/GithubConnector.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/GithubConnector.java
@@ -24,6 +24,7 @@ import java.net.HttpURLConnection;
 import java.util.concurrent.ExecutionException;
 import javax.xml.bind.DatatypeConverter;
 import net.mostlyharmless.jghservice.connector.UnexpectedResponseException;
+import net.mostlyharmless.jghservice.resources.ServiceConfig;
 
 /**
  *
@@ -33,11 +34,20 @@ public class GithubConnector
 {
     private final String encodedUserPass;
     private final String userAgentName;
+    private final String apiUrlBase;
     
-    public GithubConnector(String username, String password)
+    public GithubConnector(ServiceConfig config)
     {
-        encodedUserPass = DatatypeConverter.printBase64Binary((username + ":" + password).getBytes());
-        userAgentName = username;
+        encodedUserPass = DatatypeConverter.printBase64Binary((config.getGithub().getUsername() + ":" + config.getGithub().getPassword()).getBytes());
+        userAgentName = config.getGithub().getUsername();
+        
+        String base = config.getGithub().getUrl();
+        if (!base.endsWith("/"))
+        {
+            base = base + "/";
+        }
+        
+        apiUrlBase = base;
     }
     
     public <T> T execute(GithubCommand<T> command) throws ExecutionException
@@ -45,7 +55,7 @@ public class GithubConnector
         
         try
         {
-            HttpURLConnection conn = (HttpURLConnection) command.getUrl().openConnection();
+            HttpURLConnection conn = (HttpURLConnection) command.getUrl(apiUrlBase).openConnection();
             conn.setRequestMethod(command.getRequestMethod());
             conn.setRequestProperty("Authorization", "Basic " + encodedUserPass);
             conn.setRequestProperty("User-Agent", userAgentName);

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/ModifyComment.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/ModifyComment.java
@@ -47,9 +47,9 @@ public class ModifyComment implements GithubCommand<Integer>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE +
+        return new URL(apiUrlBase +
                        repo.getGithubOwner() + 
                         "/" + 
                         repo.getGithubName() + 

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/ModifyIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/ModifyIssue.java
@@ -47,9 +47,9 @@ public class ModifyIssue extends CreateIssue
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + repo.getGithubOwner() + 
+        return new URL(apiUrlBase + repo.getGithubOwner() + 
                         "/" + repo.getGithubName() + "/issues/" + issueNumber );
     }
     

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/PostComment.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/PostComment.java
@@ -47,9 +47,9 @@ public class PostComment implements GithubCommand<Integer>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        String urlString =  API_URL_BASE + 
+        String urlString =  apiUrlBase + 
                             repo.getGithubOwner() + 
                             "/" + 
                             repo.getGithubName() + 

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/UpdatePullRequest.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/UpdatePullRequest.java
@@ -54,9 +54,9 @@ public class UpdatePullRequest implements GithubCommand<Integer>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + repo.getGithubOwner() + 
+        return new URL(apiUrlBase + repo.getGithubOwner() + 
                         "/" + repo.getGithubName() + "/pulls/" +
                         prNumber);
     }

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/AddExternalLinkToIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/AddExternalLinkToIssue.java
@@ -57,9 +57,9 @@ public class AddExternalLinkToIssue implements JiraCommand<String>
     
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + "issue/" + jiraIssueKey + "/remotelink");
+        return new URL(apiUrlBase + "issue/" + jiraIssueKey + "/remotelink");
     }
 
     @Override

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/CreateIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/CreateIssue.java
@@ -52,9 +52,9 @@ public class CreateIssue implements JiraCommand<String>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + "issue");
+        return new URL(apiUrlBase + "issue");
                            
     }
 

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/GetIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/GetIssue.java
@@ -38,9 +38,9 @@ public class GetIssue implements JiraCommand<JiraEvent.Issue>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + "issue/" + issueKey);
+        return new URL(apiUrlBase + "issue/" + issueKey);
     }
 
     @Override

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/GetProjectKeys.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/GetProjectKeys.java
@@ -39,9 +39,9 @@ public class GetProjectKeys implements JiraCommand<List<String>>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + "project");
+        return new URL(apiUrlBase + "project");
     }
 
     @Override

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/JiraCommand.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/JiraCommand.java
@@ -31,7 +31,6 @@ import java.net.URL;
  */
 public interface JiraCommand<T>
 {
-    final static String API_URL_BASE = "https://bashoeng.atlassian.net/rest/api/2/";
     final static String POST = "POST";
     final static String PUT = "PUT";
     final static String GET = "GET";
@@ -41,7 +40,7 @@ public interface JiraCommand<T>
         .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
         .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     
-    URL getUrl() throws MalformedURLException;
+    URL getUrl(String apiUrlBase) throws MalformedURLException;
     String getJson() throws JsonProcessingException;
     String getRequestMethod();
     int getExpectedResponseCode();

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/PostComment.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/PostComment.java
@@ -43,9 +43,9 @@ public class PostComment implements JiraCommand<String>
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + "issue/" + jiraIssueKey + "/comment");
+        return new URL(apiUrlBase + "issue/" + jiraIssueKey + "/comment");
     }
 
     @Override

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/SearchIssues.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/SearchIssues.java
@@ -44,9 +44,9 @@ public class SearchIssues implements JiraCommand<List<JiraEvent.Issue>>
     }
 
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + "search");
+        return new URL(apiUrlBase + "search");
     }
 
     @Override

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/UpdateIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/UpdateIssue.java
@@ -18,7 +18,6 @@ package net.mostlyharmless.jghservice.connector.jira;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import static net.mostlyharmless.jghservice.connector.jira.JiraCommand.API_URL_BASE;
 
 /**
  *
@@ -41,9 +40,9 @@ public class UpdateIssue extends CreateIssue
     }
     
     @Override
-    public URL getUrl() throws MalformedURLException
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
     {
-        return new URL(API_URL_BASE + "issue/" + jiraIssueKey);
+        return new URL(apiUrlBase + "issue/" + jiraIssueKey);
                            
     }
     

--- a/src/main/java/net/mostlyharmless/jghservice/resources/ServiceConfig.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/ServiceConfig.java
@@ -86,7 +86,7 @@ public class ServiceConfig
     {
         if (null == jiraProjectNames)
         {
-            JiraConnector conn = new JiraConnector(jira.getUsername(), jira.getPassword());
+            JiraConnector conn = new JiraConnector(this);
             
             GetProjectKeys get = new GetProjectKeys.Builder().build();
             try

--- a/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubWebhook.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubWebhook.java
@@ -91,8 +91,7 @@ public class GithubWebhook
     
     private void processOpenedEvent(GithubEvent event)
     {
-        JiraConnector conn = new JiraConnector(config.getJira().getUsername(),
-                                               config.getJira().getPassword());
+        JiraConnector conn = new JiraConnector(config);
         
         
         if (event.hasIssue())
@@ -319,8 +318,7 @@ public class GithubWebhook
         // send out a update notice which is kinda annoying on one hand,
         // but should work well here. 
 
-        GithubConnector ghConn = new GithubConnector(config.getGithub().getUsername(),
-                                                   config.getGithub().getPassword());
+        GithubConnector ghConn = new GithubConnector(config);
 
         for (String jKey : jiraIssueKeys)
         {
@@ -337,9 +335,9 @@ public class GithubWebhook
                     GetIssue get = new GetIssue.Builder().withIssueKey(jKey).build();
                     JiraEvent.Issue issue = conn.execute(get);
                     // update this PR body with the GH issue number
-                    if (issue.hasGithubIssueNumber())
+                    if (issue.hasGithubIssueNumber(config))
                     {
-                        body = body.replace(jKey, jKey + " (#" + issue.getGithubIssueNumber() +")");
+                        body = body.replace(jKey, jKey + " (#" + issue.getGithubIssueNumber(config) +")");
                     }
                 }
                 
@@ -380,8 +378,7 @@ public class GithubWebhook
     
     private void processCreatedEvent(GithubEvent event)
     {
-        JiraConnector conn = new JiraConnector(config.getJira().getUsername(),
-                                               config.getJira().getPassword());
+        JiraConnector conn = new JiraConnector(config);
         
         if (event.hasIssue() && event.hasComment())
         {

--- a/src/main/java/net/mostlyharmless/jghservice/resources/jira/JiraWebhook.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/jira/JiraWebhook.java
@@ -77,17 +77,16 @@ public class JiraWebhook
     {
         // If there's no mapped repo (or "Do Not Link To Repo") ... 
         // we don't care about this.
-        String ghRepo = event.getIssue().getGithubRepo();
+        String ghRepo = event.getIssue().getGithubRepo(config);
         ServiceConfig.Repository repository = 
             config.getRepoForJiraName(ghRepo);
         
         if (repository != null)
         {
             
-            GithubConnector conn = new GithubConnector(config.getGithub().getUsername(),
-                                                       config.getGithub().getPassword());
+            GithubConnector conn = new GithubConnector(config);
             
-            if (!event.getIssue().hasGithubIssueNumber())
+            if (!event.getIssue().hasGithubIssueNumber(config))
             {
                 // Originating in Jira if there's no GH #
                 // Create a new issue in GH
@@ -123,7 +122,7 @@ public class JiraWebhook
                 ModifyIssue modify =
                     new ModifyIssue.Builder()
                         .withTitle(title)
-                        .withIssueNumber(event.getIssue().getGithubIssueNumber())
+                        .withIssueNumber(event.getIssue().getGithubIssueNumber(config))
                         .addLabel("JIRA: To Do")
                         .withRepository(repository)
                         .build();
@@ -142,14 +141,13 @@ public class JiraWebhook
     private void processUpdateEvent(JiraEvent event)
     {
         // If there's no repo (or "Do Not Link To Repo") ... we don't care about this.
-        String ghRepo = event.getIssue().getGithubRepo();
+        String ghRepo = event.getIssue().getGithubRepo(config);
         ServiceConfig.Repository repository = 
             config.getRepoForJiraName(ghRepo);
         
         if (repository != null)
         {
-            GithubConnector conn = new GithubConnector(config.getGithub().getUsername(),
-                                                       config.getGithub().getPassword());
+            GithubConnector conn = new GithubConnector(config);
             if (event.hasComment())
             {
                 String body = event.getComment().getBody();
@@ -165,7 +163,7 @@ public class JiraWebhook
                     PostComment post = 
                         new PostComment.Builder()
                             .withBody(body)
-                            .withIssueNumber(event.getIssue().getGithubIssueNumber())
+                            .withIssueNumber(event.getIssue().getGithubIssueNumber(config))
                             .withRepo(repository)
                             .build();
                     try
@@ -188,7 +186,7 @@ public class JiraWebhook
                     {
                         // Status change in JIRA, update GH issue
                         int ghIssueNumber = 
-                            event.getIssue().getGithubIssueNumber();
+                            event.getIssue().getGithubIssueNumber(config);
                         
                         GetLabelsOnIssue getLabels =
                             new GetLabelsOnIssue.Builder()


### PR DESCRIPTION
This removes the hardcoding for the custom field names. It will now pull the field names from the XML config file and use them, as well as the API urls. 
