### PR TITLE
Import on comment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.mostlyharmless</groupId>
     <artifactId>jira-github-service</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>jira-github-service</name>

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/GetCommentsOnIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/GetCommentsOnIssue.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2014 Brian Roach <roach at basho dot com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.mostlyharmless.jghservice.connector.github;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import net.mostlyharmless.jghservice.resources.ObjectMapperProvider;
+import net.mostlyharmless.jghservice.resources.ServiceConfig.Repository;
+import net.mostlyharmless.jghservice.resources.github.GithubEvent;
+
+/**
+ *
+ * @author Brian Roach <roach at basho dot com>
+ */
+public class GetCommentsOnIssue implements GithubCommand<List<GithubEvent.Comment>>
+{
+    private final Repository repo;
+    private final int issueNum;
+    
+    private GetCommentsOnIssue(Builder builder)
+    {
+        this.repo = builder.repo;
+        this.issueNum = builder.issueNum;
+    }
+    
+    @Override
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
+    {
+        return new URL(apiUrlBase + 
+                        repo.getGithubOwner()+
+                        "/" +
+                        repo.getGithubName()+
+                        "/issues/" +
+                        issueNum +
+                        "/comments");
+    }
+
+    @Override
+    public String getJson() throws JsonProcessingException
+    {
+        throw new UnsupportedOperationException("Not supported for GET"); 
+    }
+
+    @Override
+    public String getRequestMethod()
+    {
+        return GET;
+    }
+
+    @Override
+    public int getExpectedResponseCode()
+    {
+        return 200;
+    }
+
+    @Override
+    public List<GithubEvent.Comment> processResponse(String jsonResponse) throws IOException
+    {
+        TypeReference<List<GithubEvent.Comment>> tr = 
+            new TypeReference<List<GithubEvent.Comment>>(){};
+        ObjectMapper m = new ObjectMapperProvider().getContext(GithubEvent.Comment.class);
+        return m.readValue(jsonResponse, tr);
+    }
+
+    public static class Builder
+    {
+        private Integer issueNum;
+        private Repository repo;
+        
+        public Builder withRepository(Repository repo)
+        {
+            this.repo = repo;
+            return this;
+        }
+        
+        public Builder withIssueNumber(int issueNum)
+        {
+            this.issueNum = issueNum;
+            return this;
+        }
+        
+        public GetCommentsOnIssue build()
+        {
+            if (repo == null || issueNum == null)
+            {
+                throw new IllegalStateException("Repo and issue number required.");
+            }
+            return new GetCommentsOnIssue(this);
+        }
+        
+    }
+    
+}

--- a/src/main/java/net/mostlyharmless/jghservice/connector/github/GithubIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/github/GithubIssue.java
@@ -18,7 +18,6 @@ package net.mostlyharmless.jghservice.connector.github;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
 

--- a/src/main/java/net/mostlyharmless/jghservice/resources/ServiceConfig.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/ServiceConfig.java
@@ -201,6 +201,8 @@ public class ServiceConfig
         private String jiraName;
         @XmlElement
         private String jiraProjectKey;
+        @XmlElement
+        private boolean importOnComment = false;
         @XmlElementWrapper(name="jiraFields")
         @XmlElement(name="field")
         private List<JiraField> jiraFields;
@@ -228,6 +230,11 @@ public class ServiceConfig
         public List<JiraField> getJiraFields()
         {
             return jiraFields;
+        }
+        
+        public boolean importOnComment()
+        {
+            return importOnComment;
         }
         
         

--- a/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubWebhook.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubWebhook.java
@@ -32,6 +32,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import net.mostlyharmless.jghservice.connector.github.GetCommentsOnIssue;
 import net.mostlyharmless.jghservice.connector.github.GithubConnector;
 import net.mostlyharmless.jghservice.connector.github.ModifyComment;
 import net.mostlyharmless.jghservice.connector.github.UpdatePullRequest;
@@ -43,6 +44,8 @@ import net.mostlyharmless.jghservice.connector.jira.PostComment;
 import net.mostlyharmless.jghservice.connector.jira.SearchIssues;
 import net.mostlyharmless.jghservice.connector.jira.UpdateIssue;
 import net.mostlyharmless.jghservice.resources.ServiceConfig;
+import net.mostlyharmless.jghservice.resources.ServiceConfig.Repository;
+import net.mostlyharmless.jghservice.resources.github.GithubEvent.Comment;
 import net.mostlyharmless.jghservice.resources.jira.JiraEvent;
 
 /**
@@ -57,13 +60,13 @@ public class GithubWebhook
     
     private static final Pattern jiraIssuePattern = 
         Pattern.compile("\\[JIRA: ([-A-Z0-9]+)\\]");
-    private final Pattern jiraCommentPattern =
+    private static final Pattern jiraCommentPattern =
         Pattern.compile("\\[posted via JIRA by .+\\]\\*\\*\\*$");
-    private final Pattern githubIssueMention =
+    private static final Pattern githubIssueMention =
         Pattern.compile("#(\\d+)");
-    private final Pattern jiraIssueMention =
+    private static final Pattern jiraIssueMention =
         Pattern.compile("(([A-Z]+)-\\d+)");
-    private final Pattern extractCustomFieldNumber =
+    private static final Pattern extractCustomFieldNumber =
         Pattern.compile("customfield_(\\d+)");
     
     private static final String GITHUB_ISSUE_OPENED = "opened";
@@ -89,10 +92,10 @@ public class GithubWebhook
         return Response.ok().build();
     }
     
-    private void processOpenedEvent(GithubEvent event)
+    private String processOpenedEvent(GithubEvent event)
     {
         JiraConnector conn = new JiraConnector(config);
-        
+        String jiraIssueKey = null;
         
         if (event.hasIssue())
         {
@@ -103,7 +106,7 @@ public class GithubWebhook
                 // Originated from JIRA, need to update JIRA with issue number and external link
 
                 String githubIssueField = config.getJira().getGithubIssueNumberField();
-                String jiraIssueKey = m.group(1);
+                jiraIssueKey = m.group(1);
 
                 UpdateIssue update = 
                     new UpdateIssue.Builder()
@@ -162,8 +165,8 @@ public class GithubWebhook
 
                 try
                 {
-                    String jiraKey = conn.execute(builder.build());
-                    createExternalLink(conn, jiraKey, event);
+                    jiraIssueKey = conn.execute(builder.build());
+                    createExternalLink(conn, jiraIssueKey, event);
                 }
                 catch (ExecutionException ex)
                 {
@@ -175,6 +178,8 @@ public class GithubWebhook
         {
             linkPullRequestToIssue(conn, event);
         }
+        
+        return jiraIssueKey;
     }
     
     private void createExternalLink(JiraConnector conn, String jiraIssueKey, GithubEvent event) throws ExecutionException
@@ -406,39 +411,68 @@ public class GithubWebhook
                     m = jiraIssuePattern.matcher(issueTitle);
                     if (m.find())
                     {
-                        body = body + " \n\n[posted via Github by " +
-                            event.getComment().getUser().getLogin() +
-                            "]";
-
-
-                        PostComment post = 
-                            new PostComment.Builder()
-                                .withIssueKey(m.group(1))
-                                .withComment(body)
-                                .build();
-                        try
-                        {
-                            conn.execute(post);
-                        }
-                        catch (ExecutionException ex)
-                        {
-                            Logger.getLogger(GithubWebhook.class.getName()).log(Level.SEVERE, null, ex);
-                        }
-
+                        postCommentToJira(conn, m.group(1), 
+                                          event.getComment().getUser().getLogin(), 
+                                          body);
                     }
                     else
                     {
                         // The issue isn't in JIRA. Check to see if we should
                         // import it. This is for when the service is added to
-                        // an existing repo
-                        String repoName = event.getRepository().getName();
-                        if (config.getRepoForGithubName(repoName).importOnComment())
+                        // a GH repo with existing issues.
+                        Repository repo = config.getRepoForGithubName(event.getRepository().getName());
+                        if (repo.importOnComment())
                         {
-                            processOpenedEvent(event);
+                            String jiraIssueKey = processOpenedEvent(event);
+                            
+                            // Now we have to import comments
+                            GithubConnector ghConn = new GithubConnector(config);
+                            
+                            GetCommentsOnIssue get =
+                                new GetCommentsOnIssue.Builder()
+                                    .withRepository(repo)
+                                    .withIssueNumber(event.getIssue().getNumber())
+                                    .build();
+                            try
+                            {
+                                List<GithubEvent.Comment> comments = ghConn.execute(get);
+                                for (Comment comment : comments)
+                                {
+                                    postCommentToJira(conn, jiraIssueKey, 
+                                                      comment.getUser().getLogin(), 
+                                                      comment.getBody());
+                                }
+                            }
+                            catch (ExecutionException ex)
+                            {
+                                Logger.getLogger(GithubWebhook.class.getName()).log(Level.SEVERE, null, ex);
+                            }
+                            
                         }
                     }
                 }
             }
+        }
+    }
+    
+    private void postCommentToJira(JiraConnector conn, String jiraIssueKey, String user, String body)
+    {
+        body = body + " \n\n[posted via Github by " +
+                            user +
+                            "]";
+
+        PostComment post = 
+            new PostComment.Builder()
+                .withIssueKey(jiraIssueKey)
+                .withComment(body)
+                .build();
+        try
+        {
+            conn.execute(post);
+        }
+        catch (ExecutionException ex)
+        {
+            Logger.getLogger(GithubWebhook.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 }

--- a/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubWebhook.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubWebhook.java
@@ -426,11 +426,19 @@ public class GithubWebhook
                         }
 
                     }
-
+                    else
+                    {
+                        // The issue isn't in JIRA. Check to see if we should
+                        // import it. This is for when the service is added to
+                        // an existing repo
+                        String repoName = event.getRepository().getName();
+                        if (config.getRepoForGithubName(repoName).importOnComment())
+                        {
+                            processOpenedEvent(event);
+                        }
+                    }
                 }
             }
-            
         }
     }
-    
 }


### PR DESCRIPTION
When adding the service to a repo(s) with existing issues there is now the option to import an existing issue to JIRA the next time someone comments on it. 

In  the service config, adding `<importOnComment>true</importOnComment>` to a repository's config will activate this feature.   

Resolves #8 
