### PR TITLE
Fixed and Affects versions now sync

### DIFF
--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/CreateIssue.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/CreateIssue.java
@@ -19,6 +19,7 @@ package net.mostlyharmless.jghservice.connector.jira;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -27,6 +28,8 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,6 +44,8 @@ public class CreateIssue implements JiraCommand<String>
     protected final String summary;
     protected final String description;
     protected final Map<String, JsonNode> customFields = new HashMap<>();
+    protected final List<String> fixVersions = new LinkedList<>();
+    protected final List<String> affectsVersions= new LinkedList<>();
     
     protected CreateIssue(Init<?> builder)
     {
@@ -49,6 +54,8 @@ public class CreateIssue implements JiraCommand<String>
         this.summary = builder.summary;
         this.description = builder.description;
         this.customFields.putAll(builder.customFields);
+        this.affectsVersions.addAll(builder.affectsVersions);
+        this.fixVersions.addAll(builder.fixVersions);
     }
     
     @Override
@@ -89,6 +96,30 @@ public class CreateIssue implements JiraCommand<String>
             fields.put("description", description);
         }
         
+        if (!fixVersions.isEmpty())
+        {
+            ArrayNode array = factory.arrayNode();
+            for (String version : fixVersions)
+            {
+                ObjectNode node = factory.objectNode();
+                node.put("name", version);
+                array.add(node);
+            }
+            fields.put("fixVersions", array);
+        }
+        
+        if (!affectsVersions.isEmpty())
+        {
+            ArrayNode array = factory.arrayNode();
+            for (String version : affectsVersions)
+            {
+                ObjectNode node = factory.objectNode();
+                node.put("name", version);
+                array.add(node);
+            }
+            fields.put("versions", array);
+        }
+        
         for (Map.Entry<String, JsonNode> entry : customFields.entrySet())
         {
             fields.put(entry.getKey(), entry.getValue());
@@ -126,6 +157,8 @@ public class CreateIssue implements JiraCommand<String>
         private final Map<String, JsonNode> customFields = new HashMap<>();
         private String summary;
         private String description;
+        private List<String> affectsVersions = new LinkedList<>();
+        private List<String> fixVersions = new LinkedList<>();
         
         public T withProjectKey(String projectKey)
         {
@@ -190,6 +223,22 @@ public class CreateIssue implements JiraCommand<String>
             ((ObjectNode)fieldNode).put(key, value);
             return self();
         }
+        
+        public T withFixVersions(List<String> fixVersions)
+        {
+            this.fixVersions.clear();
+            this.fixVersions.addAll(fixVersions);
+            return self();
+        }
+        
+        public T withAffectsVersions(List<String> affectsVersions)
+        {
+            this.affectsVersions.clear();
+            this.affectsVersions.addAll(affectsVersions);
+            return self();
+        }
+        
+        
         
         protected void validate()
         {

--- a/src/main/java/net/mostlyharmless/jghservice/connector/jira/GetProjectVersions.java
+++ b/src/main/java/net/mostlyharmless/jghservice/connector/jira/GetProjectVersions.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014 Brian Roach <roach at mostlyharmless dot net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.mostlyharmless.jghservice.connector.jira;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ * @author Brian Roach <roach at mostlyharmless dot net>
+ */
+public class GetProjectVersions implements JiraCommand<List<String>>
+{
+    private final String jiraProjectKey;
+    
+    private GetProjectVersions(Builder builder)
+    {
+        this.jiraProjectKey = builder.jiraProjectKey;
+    }
+    
+    @Override
+    public URL getUrl(String apiUrlBase) throws MalformedURLException
+    {
+        return new URL(apiUrlBase + "project/" + jiraProjectKey + "/versions");
+    }
+
+    @Override
+    public String getJson() throws JsonProcessingException
+    {
+        throw new UnsupportedOperationException("Not supported for GET."); 
+    }
+
+    @Override
+    public String getRequestMethod()
+    {
+        return GET;
+    }
+
+    @Override
+    public int getExpectedResponseCode()
+    {
+        return 200;
+    }
+
+    @Override
+    public List<String> processResponse(String jsonResponse) throws IOException
+    {
+        List<String> versions = new LinkedList<>();
+        ArrayNode array = (ArrayNode) new ObjectMapper().readTree(jsonResponse);
+        for (JsonNode version : array)
+        {
+            versions.add(version.get("name").textValue());
+        }
+        return versions;
+    }
+    
+    public static class Builder
+    {
+        private final String jiraProjectKey;
+        
+        public Builder(String jiraProjectKey)
+        {
+            this.jiraProjectKey = jiraProjectKey;
+        }
+        
+        public GetProjectVersions build()
+        {
+            return new GetProjectVersions(this);
+        }
+        
+    }
+}

--- a/src/main/java/net/mostlyharmless/jghservice/resources/ServiceConfig.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/ServiceConfig.java
@@ -230,6 +230,8 @@ public class ServiceConfig
         private List<JiraField> jiraFields;
         @XmlElement
         private boolean mapEpicsToMilestones = false;
+        @XmlElement
+        private boolean labelVersions = false;
 
         public String getGithubName()
         {
@@ -264,6 +266,11 @@ public class ServiceConfig
         public boolean importOnComment()
         {
             return importOnComment;
+        }
+        
+        public boolean labelVersions()
+        {
+            return labelVersions;
         }
         
         public static class JiraField

--- a/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubEvent.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/github/GithubEvent.java
@@ -17,6 +17,8 @@
 package net.mostlyharmless.jghservice.resources.github;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
 
 /**
  *
@@ -93,6 +95,8 @@ public class GithubEvent
         private User user;
         @JsonProperty
         private Milestone milestone;
+        @JsonProperty
+        private List<Label> labels;
 
         public String getTitle()
         {
@@ -133,7 +137,25 @@ public class GithubEvent
         {
             return milestone;
         }
+        
+        public List<Label> getLabels()
+        {
+            return Collections.unmodifiableList(labels);
+        }
+        
+        public static class Label
+        {
+            @JsonProperty
+            private String name;
+
+            public String getName()
+            {
+                return name;
+            }
+        }
     }
+    
+    
     
     public static class Milestone
     {

--- a/src/main/java/net/mostlyharmless/jghservice/resources/jira/JiraEvent.java
+++ b/src/main/java/net/mostlyharmless/jghservice/resources/jira/JiraEvent.java
@@ -22,9 +22,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import net.mostlyharmless.jghservice.resources.ServiceConfig;
@@ -97,13 +100,17 @@ public class JiraEvent
         private final String description;
         private final Reporter reporter;
         private final String issueType;
+        private final List<String> fixVersionsList;
+        private final List<String> affectsVersionsList;
         
         private final Map<String, JsonNode> customFields;
         
         public Issue(String key, String summary, String description, 
                                                  Map<String,JsonNode> customFields,
                                                  Reporter reporter,
-                                                 String type)
+                                                 String type,
+                                                 List<String> fixVersionsList,
+                                                 List<String> affectsVersionsList)
         {
             this.jiraIssueKey = key;
             this.summary = summary;
@@ -111,6 +118,8 @@ public class JiraEvent
             this.customFields = customFields;
             this.reporter = reporter;
             this.issueType = type;
+            this.fixVersionsList = fixVersionsList;
+            this.affectsVersionsList = affectsVersionsList;
         }
         
         public String getGithubRepo(ServiceConfig config)
@@ -194,6 +203,16 @@ public class JiraEvent
             return issueType.equals("Epic");
         }
         
+        public List<String> getFixVersions()
+        {
+            return Collections.unmodifiableList(fixVersionsList);
+        }
+        
+        public List<String> getAffectsVersions()
+        {
+            return Collections.unmodifiableList(affectsVersionsList);
+        }
+        
         public static class Reporter
         {
             @JsonProperty
@@ -219,6 +238,20 @@ public class JiraEvent
                 
                 String type = node.get("issuetype").get("name").textValue();
                 
+                List<String> fixVersionList = new LinkedList<>();
+                ArrayNode fixVersions = (ArrayNode) node.get("fixVersions");
+                for (JsonNode version : fixVersions)
+                {
+                    fixVersionList.add(version.get("name").textValue());
+                }
+                
+                List<String> affectsVersionList = new LinkedList<>();
+                ArrayNode affectsVersions = (ArrayNode) node.get("versions");
+                for (JsonNode version : affectsVersions)
+                {
+                    affectsVersionList.add(version.get("name").textValue());
+                }
+                
                 // Store the custom fields in a map
                 Map<String, JsonNode> customFields = new HashMap<>();
                 Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
@@ -231,7 +264,8 @@ public class JiraEvent
                     }
                 }
                 
-                return new Issue(key, summary, description, customFields, r, type);
+                return new Issue(key, summary, description, customFields, r, 
+                                    type, fixVersionList, affectsVersionList);
                 
             }
             


### PR DESCRIPTION
New `<labelVersions>` option in `<repository>` will sync Fix Version and AffectsVersions. In GH these appear as labels.

Resolves #11 
